### PR TITLE
Improve error if WebView load fails

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -81,7 +81,6 @@ import android.widget.Toast;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.getbase.floatingactionbutton.FloatingActionButton;
 import com.getbase.floatingactionbutton.FloatingActionsMenu;
-import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.CollectionHelper.CollectionIntegrityStorageCheck;
 import com.ichi2.anki.StudyOptionsFragment.StudyOptionsListener;
 import com.ichi2.anki.analytics.UsageAnalytics;
@@ -573,6 +572,16 @@ public class DeckPicker extends NavigationDrawerActivity implements
      * @return whether or not we were successful
      */
     private boolean firstCollectionOpen() {
+        if (AnkiDroidApp.webViewFailedToLoad()) {
+            new MaterialDialog.Builder(this)
+                    .title(R.string.ankidroid_init_failed_webview_title)
+                    .content(getString(R.string.ankidroid_init_failed_webview, AnkiDroidApp.getWebViewErrorMessage()))
+                    .positiveText(R.string.close)
+                    .onPositive((d, w) -> exit())
+                    .cancelable(false)
+                    .show();
+            return false;
+        }
         if (Permissions.hasStorageAccessPermission(this)) {
             Timber.i("User has permissions to access collection");
             // Show error dialog if collection could not be opened

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -330,4 +330,8 @@
     <!-- Deck Picker -->
     <string name="deck_picker_failed_deck_load">Failed to load deck ‘%s’</string>
     <string name="search_decks">Search decks</string>
+
+
+    <string name="ankidroid_init_failed_webview_title">Fatal Error</string>
+    <string name="ankidroid_init_failed_webview">AnkiDroid relies on the System WebView which is unavailable. This can happen if the system is installing updates. Please try again in a few minutes.\n\n%s</string>
 </resources>


### PR DESCRIPTION
## Purpose / Description

Previously this would crash the app with no option.

Normally caused by a WebView upgrade, but also visible on API 26 Nexus emulator

## Fixes
Fixes #5794


## How Has This Been Tested?

Android 8.0: 
![image](https://user-images.githubusercontent.com/62114487/95694118-30b00800-0c28-11eb-91cd-4f521e3b44ce.png)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code